### PR TITLE
ILogger support

### DIFF
--- a/Generate-ReleaseNotes.bat
+++ b/Generate-ReleaseNotes.bat
@@ -1,5 +1,5 @@
 rem See https://github.com/StefH/GitHubReleaseNotes for more information.
 
-SET version=3.0.23
+SET version=3.1.0
 
 GitHubReleaseNotes --output ReleaseNotes.md --skip-empty-releases --exclude-labels question invalid doc --version %version%

--- a/README.md
+++ b/README.md
@@ -32,7 +32,9 @@ For application with one or two arguments, you could probably manage with some s
 
 This is the way you define arguments for your application:
 ```csharp
-CommandLineParser.CommandLineParser parser = new CommandLineParser.CommandLineParser();
+var factory = LoggerFactory.Create(b => b.AddConsole());
+ILogger<CommandLineParser.CommandLineParser> logger = factory.CreateLogger<CommandLineParser.CommandLineParser>();
+CommandLineParser.CommandLineParser parser = new CommandLineParser.CommandLineParser(logger);
 //switch argument is meant for true/false logic
 SwitchArgument showArgument = new SwitchArgument('s', "show", "Set whether show or not", true);
 ValueArgument<decimal> version = new ValueArgument<decimal>('v', "version", "Set desired version");
@@ -60,7 +62,7 @@ try
 }
 catch (CommandLineException e)
 {
-    Console.WriteLine(e.Message);
+    logger.LogWarning(e.Message);
 }
 ```
 You can find more examples of use in the [wiki](https://github.com/j-maly/CommandLineParser/wiki).

--- a/README.md
+++ b/README.md
@@ -9,12 +9,6 @@ CommandLine Parser Library lets you easily define strongly typed command line ar
 See [Quick Start](https://github.com/j-maly/CommandLineParser/wiki) on how to use the library. 
 
 Supports the following Frameworks:
-* NET 2.0
-* NET 3.5
-* NET 4.0
-* NET 4.5
-* NET 4.5.2 and higher
-* NETStandard 1.3 and higher
 * NETStandard 2.0
 * NETStandard 2.1
 

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,3 +1,6 @@
+# 3.1.0 (13 August 2022)
+- [#82](https://github.com/j-maly/CommandLineParser/pull/82) - Replace Console.Write with ILogger using Microsoft Logging extenions. Also standardized support for only .Net Standard 2.0 and 2.1 [enhancement] contributed by [askids](https://github.com/askids)
+
 # 3.0.23 (04 August 2022)
 - [#74](https://github.com/j-maly/CommandLineParser/pull/74) - Bump System.Text.RegularExpressions from 4.3.0 to 4.3.1 in /src/CommandLineArgumentsParser [dependencies] contributed by [dependabot[bot]](https://github.com/apps/dependabot)
 - [#80](https://github.com/j-maly/CommandLineParser/pull/80) - Fixed RegexValueArgumentAttribute [bug] contributed by [StefH](https://github.com/StefH)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 os: Visual Studio 2022
 
-version: 3.0.23.{build}
+version: 3.1.0.{build}
 
 configuration:
 - Debug
@@ -15,13 +15,13 @@ build_script:
  - cmd: dotnet --info
 
  - cmd: dotnet restore src\CommandLineArgumentsParser\CommandLineArgumentsParser.csproj
- - cmd: dotnet build src\CommandLineArgumentsParser\CommandLineArgumentsParser.csproj --configuration %CONFIGURATION% --framework net452
- - cmd: dotnet build src\CommandLineArgumentsParser\CommandLineArgumentsParser.csproj --configuration %CONFIGURATION% --framework netstandard1.3
+ - cmd: dotnet build src\CommandLineArgumentsParser\CommandLineArgumentsParser.csproj --configuration %CONFIGURATION% --framework netstandard2.0
+ - cmd: dotnet build src\CommandLineArgumentsParser\CommandLineArgumentsParser.csproj --configuration %CONFIGURATION% --framework netstandard2.1
 
  - cmd: dotnet restore src\ParserTest\ParserTest.csproj
- - cmd: dotnet build src\ParserTest\ParserTest.csproj --configuration %CONFIGURATION% --framework net452
- - cmd: dotnet build src\ParserTest\ParserTest.csproj --configuration %CONFIGURATION% --framework netcoreapp1.1
- - cmd: dotnet build src\ParserTest\ParserTest.csproj --configuration %CONFIGURATION% --framework netcoreapp2.1
+ - cmd: dotnet build src\ParserTest\ParserTest.csproj --configuration %CONFIGURATION% --framework net472
+ - cmd: dotnet build src\ParserTest\ParserTest.csproj --configuration %CONFIGURATION% --framework net48
+ - cmd: dotnet build src\ParserTest\ParserTest.csproj --configuration %CONFIGURATION% --framework netcoreapp3.1
  - cmd: dotnet build src\ParserTest\ParserTest.csproj --configuration %CONFIGURATION% --framework net6.0
  
  - cmd: dotnet restore src\Tests\Tests.csproj

--- a/src/CommandLineArgumentsParser/Arguments/Argument.cs
+++ b/src/CommandLineArgumentsParser/Arguments/Argument.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Reflection;
 using CommandLineParser.Compatibility;
 using CommandLineParser.Exceptions;
+using Microsoft.Extensions.Logging;
 
 namespace CommandLineParser.Arguments;
 
@@ -251,9 +252,9 @@ public abstract class Argument
     }
 
     /// <summary>
-    /// Prints information about the argument value to the console.
+    /// Prints information about the argument value to the log.
     /// </summary>
-    public abstract void PrintValueInfo();
+    public abstract void PrintValueInfo(ILogger logger);
 
     /// <summary>
     /// Initializes the argument. Sets <see cref="Parsed"/> to false. Override in inherited classes 

--- a/src/CommandLineArgumentsParser/Arguments/BoundedValueArgument.cs
+++ b/src/CommandLineArgumentsParser/Arguments/BoundedValueArgument.cs
@@ -1,6 +1,7 @@
 using System;
 using CommandLineParser.Compatibility;
 using CommandLineParser.Exceptions;
+using Microsoft.Extensions.Logging;
 
 namespace CommandLineParser.Arguments
 {

--- a/src/CommandLineArgumentsParser/Arguments/CertifiedValueArgument.cs
+++ b/src/CommandLineArgumentsParser/Arguments/CertifiedValueArgument.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using Microsoft.Extensions.Logging;
+using System.Collections.Generic;
 
 namespace CommandLineParser.Arguments
 {

--- a/src/CommandLineArgumentsParser/Arguments/DirectoryArgument.cs
+++ b/src/CommandLineArgumentsParser/Arguments/DirectoryArgument.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Logging;
 using System.IO;
 
 namespace CommandLineParser.Arguments

--- a/src/CommandLineArgumentsParser/Arguments/EnumeratedValueArgument.cs
+++ b/src/CommandLineArgumentsParser/Arguments/EnumeratedValueArgument.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using CommandLineParser.Compatibility;
 using CommandLineParser.Exceptions;
+using Microsoft.Extensions.Logging;
 
 namespace CommandLineParser.Arguments
 {

--- a/src/CommandLineArgumentsParser/Arguments/FileArgument.cs
+++ b/src/CommandLineArgumentsParser/Arguments/FileArgument.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Logging;
 using System;
 using System.IO;
 

--- a/src/CommandLineArgumentsParser/Arguments/RegexValueArgument.cs
+++ b/src/CommandLineArgumentsParser/Arguments/RegexValueArgument.cs
@@ -2,6 +2,7 @@
 using System.Text.RegularExpressions;
 using CommandLineParser.Compatibility;
 using CommandLineParser.Exceptions;
+using Microsoft.Extensions.Logging;
 
 namespace CommandLineParser.Arguments;
 

--- a/src/CommandLineArgumentsParser/Arguments/SwitchArgument.cs
+++ b/src/CommandLineArgumentsParser/Arguments/SwitchArgument.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using CommandLineParser.Compatibility;
 using CommandLineParser.Exceptions;
+using Microsoft.Extensions.Logging;
 
 namespace CommandLineParser.Arguments
 {
@@ -113,11 +114,11 @@ namespace CommandLineParser.Arguments
         }
 
         /// <summary>
-        /// Prints information about the argument value to the console.
+        /// Prints information about the argument value to the ILogger.
         /// </summary>
-        public override void PrintValueInfo()
+        public override void PrintValueInfo(ILogger logger)
         {
-            Console.WriteLine(Messages.EXC_ARG_SWITCH_PRINT, Name, Value ? "1" : "0");
+            logger.LogInformation(Messages.IL_EXC_ARG_SWITCH_PRINT, Name, Value ? "1" : "0");
         }
 
         /// <summary>

--- a/src/CommandLineArgumentsParser/Arguments/ValueArgument.cs
+++ b/src/CommandLineArgumentsParser/Arguments/ValueArgument.cs
@@ -1,5 +1,6 @@
 using CommandLineParser.Compatibility;
 using CommandLineParser.Exceptions;
+using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
@@ -442,18 +443,18 @@ namespace CommandLineParser.Arguments
         }
 
         /// <summary>
-        /// Prints information about the argument value to the console.
+        /// Prints information about the argument value to the log.
         /// </summary>
-        public override void PrintValueInfo()
+        public override void PrintValueInfo(ILogger logger)
         {
             if (!AllowMultiple)
             {
-                Console.WriteLine(Messages.EXC_ARG_VALUE_PRINT, Name, _stringValue, _value, typeof(TValue).Name);
+                logger.LogInformation(Messages.IL_EXC_ARG_VALUE_PRINT, Name, _stringValue, _value, typeof(TValue).Name);
             }
             else
             {
                 string valuesString = string.Join(", ", _values.Select(v => v.ToString()).ToArray());
-                Console.WriteLine(Messages.EXC_ARG_VALUE_PRINT_MULTIPLE, Name, Values.Count, valuesString, typeof(TValue).Name);
+                logger.LogInformation(Messages.IL_EXC_ARG_VALUE_PRINT_MULTIPLE, Name, Values.Count, valuesString, typeof(TValue).Name);
             }
         }
     }

--- a/src/CommandLineArgumentsParser/CommandLineArgumentsParser.csproj
+++ b/src/CommandLineArgumentsParser/CommandLineArgumentsParser.csproj
@@ -6,7 +6,7 @@
         <Authors>Jakub Maly;Stef Heyenrath;NTTAKR</Authors>
         <Copyright>Copyright Jakub Maly &amp; Stef Heyenrath © 2018-2022</Copyright>
         <Company>Jakub Maly</Company>
-        <TargetFrameworks>net20;net35;net40;net45;net452;netstandard1.3;netstandard2.0;netstandard2.1</TargetFrameworks>
+        <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
         <AssemblyName>CommandLineArgumentsParser</AssemblyName>
         <RootNamespace>CommandLineParser</RootNamespace>
         <PackageId>CommandLineArgumentsParser</PackageId>
@@ -16,7 +16,7 @@
         <PackageReleaseNotes>See ReleaseNotes.md</PackageReleaseNotes>
         <RepositoryType>git</RepositoryType>
         <RepositoryUrl>https://github.com/j-maly/CommandLineParser</RepositoryUrl>
-        <Version>3.0.23</Version>
+        <Version>3.1.0</Version>
         <DebugType>full</DebugType>
         <SignAssembly>true</SignAssembly>
         <AssemblyOriginatorKeyFile>CommandLineArgumentsParser.snk</AssemblyOriginatorKeyFile>
@@ -30,30 +30,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
-    </ItemGroup>
-
-    <ItemGroup Condition=" '$(TargetFramework)' == 'net20' ">
-        <PackageReference Include="LinqBridge" Version="1.3.0" />
-    </ItemGroup>
-
-    <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
-        <DefineConstants>$(DefineConstants);NETSTANDARD</DefineConstants>
-    </PropertyGroup>
-
-    <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
-        <PackageReference Include="Microsoft.CSharp" Version="4.3.0" />
-        <PackageReference Include="System.Collections" Version="4.3.0" />
-        <PackageReference Include="System.Console" Version="4.3.0" />
-        <PackageReference Include="System.Globalization" Version="4.3.0" />
-        <PackageReference Include="System.IO.FileSystem" Version="4.3.0" />
-        <PackageReference Include="System.Linq" Version="4.3.0" />
-        <PackageReference Include="System.Reflection.Extensions" Version="4.3.0" />
-        <PackageReference Include="System.Reflection.TypeExtensions" Version="4.3.0" />
-        <PackageReference Include="System.Resources.ResourceManager" Version="4.3.0" />
-        <PackageReference Include="System.Runtime.Extensions" Version="4.3.0" />
-        <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />
-        <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
+        <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
     </ItemGroup>
 
 </Project>

--- a/src/CommandLineArgumentsParser/CommandLineParser.cs
+++ b/src/CommandLineArgumentsParser/CommandLineParser.cs
@@ -3,11 +3,13 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Text;
 using System.Text.RegularExpressions;
 using CommandLineParser.Arguments;
 using CommandLineParser.Compatibility;
 using CommandLineParser.Exceptions;
 using CommandLineParser.Validation;
+using Microsoft.Extensions.Logging;
 
 namespace CommandLineParser;
 
@@ -41,7 +43,7 @@ public class CommandLineParser : IDisposable
     private readonly AdditionalArgumentsSettings _additionalArgumentsSettings = new AdditionalArgumentsSettings();
 
     private readonly List<string> _showUsageCommands = new List<string> { "--help", "/?", "/help" };
-
+    private readonly ILogger<CommandLineParser> _logger;
     private bool _acceptSlash = true;
 
     private bool _acceptHyphen = true;
@@ -54,6 +56,10 @@ public class CommandLineParser : IDisposable
 
     #endregion
 
+    public CommandLineParser(ILogger<CommandLineParser> logger)
+    {
+        _logger = logger;
+    }
     /// <summary>
     /// Defined command line arguments
     /// </summary>
@@ -617,82 +623,81 @@ public class CommandLineParser : IDisposable
     }
 
     /// <summary>
-    /// Prints arguments information and usage information to
-    /// the <paramref name="outputStream"/>. 
+    /// Prints arguments information and usage information using ILogger
     /// </summary>
-    public void PrintUsage(TextWriter outputStream)
+    public void PrintUsage()
     {
-        outputStream.WriteLine(ShowUsageHeader);
-
-        outputStream.WriteLine(Messages.MSG_USAGE);
-
+        _logger.LogInformation(ShowUsageHeader);
+        _logger.LogInformation(Messages.MSG_USAGE);
+        var sb = new StringBuilder();
         foreach (Argument argument in _arguments)
         {
-            outputStream.Write("\t");
+            sb.Append("\t");
             bool comma = false;
             if (argument.ShortName.HasValue)
             {
-                outputStream.Write("-" + argument.ShortName);
+                sb.Append("-" + argument.ShortName);
                 comma = true;
             }
             foreach (char c in argument.ShortAliases)
             {
                 if (comma)
-                    outputStream.WriteLine(", ");
-                outputStream.Write("-" + c);
+                    sb.Append(", ");
+                sb.Append("-" + c);
                 comma = true;
             }
             if (!string.IsNullOrEmpty(argument.LongName))
             {
                 if (comma)
-                    outputStream.Write(", ");
-                outputStream.Write("--" + argument.LongName);
+                    sb.Append(", ");
+                sb.Append("--" + argument.LongName);
                 comma = true;
             }
             foreach (string str in argument.LongAliases)
             {
                 if (comma)
-                    outputStream.Write(", ");
-                outputStream.Write("--" + str);
+                    sb.Append(", ");
+                sb.Append("--" + str);
                 comma = true;
             }
 
             if (argument.Optional)
-                outputStream.Write(Messages.MSG_OPTIONAL);
-            outputStream.WriteLine("... {0} ", argument.Description);
+                sb.Append(Messages.MSG_OPTIONAL);
+            _logger.LogInformation(sb.ToString());
+            _logger.LogInformation($"... {argument.Description} ");
 
             if (!string.IsNullOrEmpty(argument.Example))
             {
-                outputStream.WriteLine(Messages.MSG_EXAMPLE_FORMAT, argument.Example);
+                _logger.LogInformation(Messages.IL_MSG_EXAMPLE_FORMAT, argument.Example);
             }
 
             if (!string.IsNullOrEmpty(argument.FullDescription))
             {
-                outputStream.WriteLine();
-                outputStream.WriteLine(argument.FullDescription);
+                _logger.LogInformation(Messages.IL_MSG_FULL_DESC, argument.FullDescription);
             }
-            outputStream.WriteLine();
         }
 
         if (Certifications.Count > 0)
         {
-            outputStream.WriteLine(Messages.CERT_REMARKS);
+            sb.Clear();
+            sb.AppendLine(Messages.CERT_REMARKS);
             foreach (ArgumentCertification certification in Certifications)
             {
-                outputStream.WriteLine("\t" + certification.Description);
+                sb.Append("\t" + certification.Description);
             }
-            outputStream.WriteLine();
+            _logger.LogInformation(sb.ToString());
         }
 
-        outputStream.WriteLine(ShowUsageFooter);
+        _logger.LogInformation(ShowUsageFooter);
+
     }
 
     /// <summary>
-    /// Prints arguments information and usage information to the console. 
+    /// Prints arguments information and usage information to the ILogger. 
     /// </summary>
     public void ShowUsage()
     {
-        PrintUsage(Console.Out);
+        PrintUsage();
     }
 
     /// <summary>
@@ -700,41 +705,38 @@ public class CommandLineParser : IDisposable
     /// </summary>
     public void ShowParsedArguments(bool showOmittedArguments = false)
     {
-        Console.WriteLine(Messages.MSG_PARSING_RESULTS);
-        Console.WriteLine("\t" + Messages.MSG_COMMAND_LINE);
+        var sb = new StringBuilder();
+        sb.AppendLine(Messages.MSG_PARSING_RESULTS);
+        sb.Append("\t" + Messages.MSG_COMMAND_LINE);
         foreach (string arg in _argsNotParsed)
         {
-            Console.Write(arg);
-            Console.Write(" ");
+            sb.Append(arg);
+            sb.Append(" ");
         }
 
-        Console.WriteLine();
-        Console.WriteLine();
-        Console.WriteLine("\t" + Messages.MSG_PARSED_ARGUMENTS);
+        sb.AppendLine("\t" + Messages.MSG_PARSED_ARGUMENTS);
+        _logger.LogInformation(sb.ToString());
         foreach (Argument argument in _arguments)
         {
             if (argument.Parsed)
-                argument.PrintValueInfo();
+                argument.PrintValueInfo(_logger);
         }
-        Console.WriteLine();
-        Console.WriteLine("\t" + Messages.MSG_NOT_PARSED_ARGUMENTS);
+        _logger.LogInformation(Messages.MSG_NOT_PARSED_ARGUMENTS);
         foreach (Argument argument in _arguments)
         {
             if (!argument.Parsed)
-                argument.PrintValueInfo();
+                argument.PrintValueInfo(_logger);
         }
-        Console.WriteLine();
         if (AdditionalArgumentsSettings.AcceptAdditionalArguments)
         {
-            Console.WriteLine("\t" + Messages.MSG_ADDITIONAL_ARGUMENTS);
-
+            _logger.LogInformation(Messages.MSG_ADDITIONAL_ARGUMENTS);
+            sb.Clear();
             foreach (string simpleArgument in AdditionalArgumentsSettings.AdditionalArguments)
             {
-                Console.Write(simpleArgument + " ");
+                sb.Append(simpleArgument + " ");
             }
 
-            Console.WriteLine();
-            Console.WriteLine();
+            _logger.LogInformation(sb.ToString());
         }
     }
 

--- a/src/CommandLineArgumentsParser/Messages.cs
+++ b/src/CommandLineArgumentsParser/Messages.cs
@@ -20,6 +20,7 @@ internal static class Messages
     public static string EXC_ARG_NOT_ONE_WORD = "LongName of an argument must be one word.";
 
     public static string EXC_ARG_SWITCH_PRINT = "Argument: {0} value: {1}";
+    public static string IL_EXC_ARG_SWITCH_PRINT = "Argument: {@Argument} value: {@Value}";
 
     public static string EXC_ARG_UNKNOWN = "Unknown argument found: {0}.";
 
@@ -30,8 +31,10 @@ internal static class Messages
     public static string EXC_ARG_VALUE_MULTIPLE_OCCURS = "Argument {0} can not be used multiple times.";
 
     public static string EXC_ARG_VALUE_PRINT = "Argument: {0}, type: {3}, value: {2} (converted from: {1})";
+    public static string IL_EXC_ARG_VALUE_PRINT = "Argument: {@Argument}, type: {@Type}, value: {@Value} (converted from: {@ConvertedFrom})";
 
     public static string EXC_ARG_VALUE_PRINT_MULTIPLE = "Argument: {0}, type: {3}, occurred {1}x values: {2}";
+    public static string IL_EXC_ARG_VALUE_PRINT_MULTIPLE = "Argument: {@Argument}, type: {@Type}, occurred {@occured}x values: {@Values}";
 
     public static string EXC_ARG_VALUE_STANDARD_CONVERT_FAILED = "Failed to convert string {0} to type {1}. Use strings in accepted format or define custom conversion using ConvertValueHandler.";
 
@@ -90,6 +93,8 @@ internal static class Messages
     public static string EXC_NOT_ENOUGH_ADDITIONAL_ARGUMENTS = "Not enough additional arguments. Needed {0} additional arguments.";
 
     public static string MSG_EXAMPLE_FORMAT = "Example: {0}";
+    public static string IL_MSG_EXAMPLE_FORMAT = "Example: {@Example}";
+    public static string IL_MSG_FULL_DESC = "Full Description: {@FullDescription}";
 
     // public static string EXC_GROUP_ALL_OR_NONE_USED_NOT_ALL_USED = "All or none of these arguments: {0} must be used.";
 

--- a/src/ParserTest/ParserTest.csproj
+++ b/src/ParserTest/ParserTest.csproj
@@ -2,11 +2,15 @@
 
   <PropertyGroup>
     <Authors>Jakub Maly;Stef Heyenrath</Authors>	
-    <TargetFrameworks>net20;net35;net40;net45;net452;netcoreapp1.1;netcoreapp2.1;net6.0</TargetFrameworks>
+    <TargetFrameworks>net472;net48;netcoreapp3.1;net6.0</TargetFrameworks>
     <AssemblyName>ParserTest</AssemblyName>
     <OutputType>Exe</OutputType>
     <PackageId>ParserTest</PackageId>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
+  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\CommandLineArgumentsParser\CommandLineArgumentsParser.csproj" />

--- a/src/ParserTest/Program.cs
+++ b/src/ParserTest/Program.cs
@@ -4,6 +4,7 @@ using System.IO;
 using CommandLineParser.Arguments;
 using CommandLineParser.Exceptions;
 using CommandLineParser.Validation;
+using Microsoft.Extensions.Logging;
 
 namespace ParserTest
 {
@@ -54,7 +55,9 @@ namespace ParserTest
     {
         public static void Main(string[] args)
         {
-            var parser = new CommandLineParser.CommandLineParser();
+            var factory = LoggerFactory.Create(b => b.AddConsole());
+            ILogger<CommandLineParser.CommandLineParser> logger = factory.CreateLogger<CommandLineParser.CommandLineParser>();
+            var parser = new CommandLineParser.CommandLineParser(logger);
             parser.ShowUsageOnEmptyCommandline = true;
 
             var p = new ParsingTarget();
@@ -82,20 +85,18 @@ namespace ParserTest
                 try
                 {
                     if (arguments.Length == 0)
-                        Console.WriteLine("INPUT: No arguments supplied.");
+                        logger.LogWarning("INPUT: No arguments supplied.");
                     else
-                        Console.WriteLine("INPUT: {0}", arguments);
+                        logger.LogInformation("INPUT: {0}", arguments);
 
                     parser.ParseCommandLine(arguments);
 
                     parser.ShowParsedArguments(true);
-                    Console.WriteLine("RESULT: OK");
-                    Console.WriteLine();
+                    logger.LogInformation("RESULT: OK");
                 }
                 catch (CommandLineException e)
                 {
-                    Console.WriteLine("RESULT: EXC - " + e.Message);
-                    Console.WriteLine();
+                    logger.LogError("RESULT: EXC - " + e.Message);
                 }
             }
 
@@ -121,15 +122,13 @@ namespace ParserTest
             }
             catch (CommandLineException e)
             {
-                Console.WriteLine("RESULT: EXC - " + e.Message);
-                Console.WriteLine();
+                logger.LogError("RESULT: EXC - " + e.Message);
             }
 
             // two files - OK 
             parser.ParseCommandLine(new[] { "/d", "C:\\Input", "file1.txt", "file2.txt" });
             parser.ShowParsedArguments();
-            Console.WriteLine("RESULT: OK");
-            Console.WriteLine();
+            logger.LogInformation("RESULT: OK");
         }
     }
 }

--- a/src/Tests/MandatoryArgumentsTests.cs
+++ b/src/Tests/MandatoryArgumentsTests.cs
@@ -110,10 +110,11 @@ namespace Tests
             commandLineParser.ExtractArgumentAttributes(target);
 
             // Act
-            commandLineParser.ParseCommandLine(args);
+            Action act = () => commandLineParser.ParseCommandLine(args);
 
             // Assert
-            target.Severity.Should().BeNull();
+            act.Should().Throw<MandatoryArgumentNotSetException>();
+
         }
     }
 }

--- a/src/Tests/MandatoryArgumentsTests.cs
+++ b/src/Tests/MandatoryArgumentsTests.cs
@@ -1,6 +1,7 @@
 using CommandLineParser.Arguments;
 using CommandLineParser.Exceptions;
 using FluentAssertions;
+using Microsoft.Extensions.Logging;
 using System;
 using Xunit;
 
@@ -25,8 +26,9 @@ namespace Tests
         {
             // Assign
             string[] args = { "-s", "test" };
-
-            var commandLineParser = new CommandLineParser.CommandLineParser();
+            var factory = LoggerFactory.Create(b => b.AddConsole());
+            ILogger<CommandLineParser.CommandLineParser> logger = factory.CreateLogger<CommandLineParser.CommandLineParser>();
+            var commandLineParser = new CommandLineParser.CommandLineParser(logger);
             var target = new TestTargetWithOptionalTrue();
             commandLineParser.ExtractArgumentAttributes(target);
 
@@ -43,7 +45,9 @@ namespace Tests
             // Assign
             string[] args = { "-s", "test" };
 
-            var commandLineParser = new CommandLineParser.CommandLineParser();
+            var factory = LoggerFactory.Create(b => b.AddConsole());
+            ILogger<CommandLineParser.CommandLineParser> logger = factory.CreateLogger<CommandLineParser.CommandLineParser>();
+            var commandLineParser = new CommandLineParser.CommandLineParser(logger);
             var target = new TestTargetWithOptionalFalse();
             commandLineParser.ExtractArgumentAttributes(target);
 
@@ -60,7 +64,9 @@ namespace Tests
             // Assign
             string[] args = { };
 
-            var commandLineParser = new CommandLineParser.CommandLineParser();
+            var factory = LoggerFactory.Create(b => b.AddConsole());
+            ILogger<CommandLineParser.CommandLineParser> logger = factory.CreateLogger<CommandLineParser.CommandLineParser>();
+            var commandLineParser = new CommandLineParser.CommandLineParser(logger);
             var target = new TestTargetWithOptionalTrue();
             commandLineParser.ExtractArgumentAttributes(target);
 
@@ -77,7 +83,9 @@ namespace Tests
             // Assign
             string[] args = { };
 
-            var commandLineParser = new CommandLineParser.CommandLineParser();
+            var factory = LoggerFactory.Create(b => b.AddConsole());
+            ILogger<CommandLineParser.CommandLineParser> logger = factory.CreateLogger<CommandLineParser.CommandLineParser>();
+            var commandLineParser = new CommandLineParser.CommandLineParser(logger);
             var target = new TestTargetWithOptionalFalse();
             commandLineParser.ExtractArgumentAttributes(target);
 
@@ -94,7 +102,9 @@ namespace Tests
             // Assign
             string[] args = { };
 
-            var commandLineParser = new CommandLineParser.CommandLineParser { CheckMandatoryArguments = false };
+            var factory = LoggerFactory.Create(b => b.AddConsole());
+            ILogger<CommandLineParser.CommandLineParser> logger = factory.CreateLogger<CommandLineParser.CommandLineParser>();
+            var commandLineParser = new CommandLineParser.CommandLineParser(logger);
 
             var target = new TestTargetWithOptionalFalse();
             commandLineParser.ExtractArgumentAttributes(target);

--- a/src/Tests/Tests.AdditionalArguments.cs
+++ b/src/Tests/Tests.AdditionalArguments.cs
@@ -1,5 +1,6 @@
 using CommandLineParser.Arguments;
 using CommandLineParser.Exceptions;
+using Microsoft.Extensions.Logging;
 using ParserTest;
 using Xunit;
 
@@ -9,7 +10,10 @@ namespace Tests
     {
         public CommandLineParser.CommandLineParser InitAdditionalArguments()
         {
-            var commandLineParser = new CommandLineParser.CommandLineParser();
+            var factory = LoggerFactory.Create(b => b.AddConsole());
+            ILogger<CommandLineParser.CommandLineParser> logger = factory.CreateLogger<CommandLineParser.CommandLineParser>();
+
+            var commandLineParser = new CommandLineParser.CommandLineParser(logger);
             commandLineParser.ShowUsageOnEmptyCommandline = true;
 
             SwitchArgument showArgument = new SwitchArgument('s', "show", "Set whether show or not", true);

--- a/src/Tests/Tests.BoundedValueArgument.cs
+++ b/src/Tests/Tests.BoundedValueArgument.cs
@@ -1,5 +1,6 @@
 using CommandLineParser.Arguments;
 using CommandLineParser.Exceptions;
+using Microsoft.Extensions.Logging;
 using System.Collections.Generic;
 using Xunit;
 
@@ -20,7 +21,9 @@ namespace Tests
 
         public CommandLineParser.CommandLineParser InitBoundedValueArgument()
         {
-            var commandLineParser = new CommandLineParser.CommandLineParser();
+            var factory = LoggerFactory.Create(b => b.AddConsole());
+            ILogger<CommandLineParser.CommandLineParser> logger = factory.CreateLogger<CommandLineParser.CommandLineParser>();
+            var commandLineParser = new CommandLineParser.CommandLineParser(logger);
             boundedValueArgumentTarget = new BoundedValueArgumentParsingTarget();
             commandLineParser.ExtractArgumentAttributes(boundedValueArgumentTarget);
             return commandLineParser;

--- a/src/Tests/Tests.CertifiedValueArgument.cs
+++ b/src/Tests/Tests.CertifiedValueArgument.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using CommandLineParser.Arguments;
 using CommandLineParser.Exceptions;
 using FluentAssertions;
+using Microsoft.Extensions.Logging;
 using Xunit;
 
 namespace Tests;
@@ -22,7 +23,9 @@ public partial class Tests
 
     public CommandLineParser.CommandLineParser InitForCertifiedValueArgument()
     {
-        var commandLineParser = new CommandLineParser.CommandLineParser();
+        var factory = LoggerFactory.Create(b => b.AddConsole());
+        ILogger<CommandLineParser.CommandLineParser> logger = factory.CreateLogger<CommandLineParser.CommandLineParser>();
+        var commandLineParser = new CommandLineParser.CommandLineParser(logger);
         _certifiedValueArgumentParsingTarget = new CertifiedValueArgumentParsingTarget();
         commandLineParser.ExtractArgumentAttributes(_certifiedValueArgumentParsingTarget);
 
@@ -83,7 +86,9 @@ public partial class Tests
     [Fact]
     public void ValueArgument_ShouldParseDate()
     {
-        var commandLineParser = new CommandLineParser.CommandLineParser();
+        var factory = LoggerFactory.Create(b => b.AddConsole());
+        ILogger<CommandLineParser.CommandLineParser> logger = factory.CreateLogger<CommandLineParser.CommandLineParser>();
+        var commandLineParser = new CommandLineParser.CommandLineParser(logger);
         ValueArgument<DateTime> dateTime = new ValueArgument<DateTime>('d', "date");
         commandLineParser.Arguments.Add(dateTime);
 

--- a/src/Tests/Tests.DeclarativeArguments.cs
+++ b/src/Tests/Tests.DeclarativeArguments.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using CommandLineParser.Arguments;
 using CommandLineParser.Exceptions;
+using Microsoft.Extensions.Logging;
 using ParserTest;
 using Xunit;
 
@@ -46,7 +47,9 @@ public partial class Tests
 
     private CommandLineParser.CommandLineParser InitDeclarativeArguments()
     {
-        var commandLineParser = new CommandLineParser.CommandLineParser();
+        var factory = LoggerFactory.Create(b => b.AddConsole());
+        ILogger<CommandLineParser.CommandLineParser> logger = factory.CreateLogger<CommandLineParser.CommandLineParser>();
+        var commandLineParser = new CommandLineParser.CommandLineParser(logger);
         DeclarativeArgumentsParsingTarget p = new DeclarativeArgumentsParsingTarget();
 
         // read the argument attributes 

--- a/src/Tests/Tests.DeclarativeSwitch.cs
+++ b/src/Tests/Tests.DeclarativeSwitch.cs
@@ -1,4 +1,5 @@
 using CommandLineParser.Arguments;
+using Microsoft.Extensions.Logging;
 using Xunit;
 
 namespace Tests
@@ -42,7 +43,9 @@ namespace Tests
         [Fact]
         public void DeclarativeSwitch_SwitchArgumentTrueDefault()
         {
-            var parser = new CommandLineParser.CommandLineParser();
+            var factory = LoggerFactory.Create(b => b.AddConsole());
+            ILogger<CommandLineParser.CommandLineParser> logger = factory.CreateLogger<CommandLineParser.CommandLineParser>();
+            var parser = new CommandLineParser.CommandLineParser(logger);
             var options = new TestOptionsTrue();
             parser.ExtractArgumentAttributes(options);
 
@@ -54,7 +57,9 @@ namespace Tests
         [Fact]
         public void DeclarativeSwitch_SwitchArgumentTrueSet()
         {
-            var parser = new CommandLineParser.CommandLineParser();
+            var factory = LoggerFactory.Create(b => b.AddConsole());
+            ILogger<CommandLineParser.CommandLineParser> logger = factory.CreateLogger<CommandLineParser.CommandLineParser>();
+            var parser = new CommandLineParser.CommandLineParser(logger);
             var options = new TestOptionsTrue();
             parser.ExtractArgumentAttributes(options);
 
@@ -66,7 +71,9 @@ namespace Tests
         [Fact]
         public void DeclarativeSwitch_SwitchArgumentFalseDefault()
         {
-            var parser = new CommandLineParser.CommandLineParser();
+            var factory = LoggerFactory.Create(b => b.AddConsole());
+            ILogger<CommandLineParser.CommandLineParser> logger = factory.CreateLogger<CommandLineParser.CommandLineParser>();
+            var parser = new CommandLineParser.CommandLineParser(logger);
             var options = new TestOptionsFalse();
             parser.ExtractArgumentAttributes(options);
 
@@ -78,7 +85,9 @@ namespace Tests
         [Fact]
         public void DeclarativeSwitch_SwitchArgumentFalseSet()
         {
-            var parser = new CommandLineParser.CommandLineParser();
+            var factory = LoggerFactory.Create(b => b.AddConsole());
+            ILogger<CommandLineParser.CommandLineParser> logger = factory.CreateLogger<CommandLineParser.CommandLineParser>();
+            var parser = new CommandLineParser.CommandLineParser(logger);
             var options = new TestOptionsFalse();
             parser.ExtractArgumentAttributes(options);
 
@@ -90,7 +99,9 @@ namespace Tests
         [Fact]
         public void PathAsAnArgumentShouldNotBreakThings()
         {
-            var parser = new CommandLineParser.CommandLineParser();
+            var factory = LoggerFactory.Create(b => b.AddConsole());
+            ILogger<CommandLineParser.CommandLineParser> logger = factory.CreateLogger<CommandLineParser.CommandLineParser>();
+            var parser = new CommandLineParser.CommandLineParser(logger);
             var options = new TestOptionsFalse();
             parser.ExtractArgumentAttributes(options);
 

--- a/src/Tests/Tests.DeclarativeValue.cs
+++ b/src/Tests/Tests.DeclarativeValue.cs
@@ -1,4 +1,5 @@
 using CommandLineParser.Arguments;
+using Microsoft.Extensions.Logging;
 using Xunit;
 
 namespace Tests
@@ -39,7 +40,9 @@ namespace Tests
         [Fact]
         public void DeclarativeValue_SwitchArgumentTrueDefault()
         {
-            var parser = new CommandLineParser.CommandLineParser();
+            var factory = LoggerFactory.Create(b => b.AddConsole());
+            ILogger<CommandLineParser.CommandLineParser> logger = factory.CreateLogger<CommandLineParser.CommandLineParser>();
+            var parser = new CommandLineParser.CommandLineParser(logger);
             var options = new DeclarativeValueTestOptionsTrue();
             parser.ExtractArgumentAttributes(options);
 
@@ -51,7 +54,9 @@ namespace Tests
         [Fact]
         public void DeclarativeValue_SwitchArgumentTrueSetTrue()
         {
-            var parser = new CommandLineParser.CommandLineParser();
+            var factory = LoggerFactory.Create(b => b.AddConsole());
+            ILogger<CommandLineParser.CommandLineParser> logger = factory.CreateLogger<CommandLineParser.CommandLineParser>();
+            var parser = new CommandLineParser.CommandLineParser(logger);
             var options = new DeclarativeValueTestOptionsTrue();
             parser.ExtractArgumentAttributes(options);
 
@@ -63,7 +68,9 @@ namespace Tests
         [Fact]
         public void DeclarativeValue_SwitchArgumentTrueSetFalse()
         {
-            var parser = new CommandLineParser.CommandLineParser();
+            var factory = LoggerFactory.Create(b => b.AddConsole());
+            ILogger<CommandLineParser.CommandLineParser> logger = factory.CreateLogger<CommandLineParser.CommandLineParser>();
+            var parser = new CommandLineParser.CommandLineParser(logger);
             var options = new DeclarativeValueTestOptionsTrue();
             parser.ExtractArgumentAttributes(options);
 
@@ -75,7 +82,9 @@ namespace Tests
         [Fact]
         public void DeclarativeValue_SwitchArgumentFalseDefault()
         {
-            var parser = new CommandLineParser.CommandLineParser();
+            var factory = LoggerFactory.Create(b => b.AddConsole());
+            ILogger<CommandLineParser.CommandLineParser> logger = factory.CreateLogger<CommandLineParser.CommandLineParser>();
+            var parser = new CommandLineParser.CommandLineParser(logger);
             var options = new DeclarativeValueTestOptionsFalse();
             parser.ExtractArgumentAttributes(options);
 
@@ -87,7 +96,9 @@ namespace Tests
         [Fact]
         public void DeclarativeValue_SwitchArgumentFalseSetFalse()
         {
-            var parser = new CommandLineParser.CommandLineParser();
+            var factory = LoggerFactory.Create(b => b.AddConsole());
+            ILogger<CommandLineParser.CommandLineParser> logger = factory.CreateLogger<CommandLineParser.CommandLineParser>();
+            var parser = new CommandLineParser.CommandLineParser(logger);
             var options = new DeclarativeValueTestOptionsFalse();
             parser.ExtractArgumentAttributes(options);
 
@@ -99,7 +110,9 @@ namespace Tests
         [Fact]
         public void DeclarativeValue_SwitchArgumentFalseSetTrue()
         {
-            var parser = new CommandLineParser.CommandLineParser();
+            var factory = LoggerFactory.Create(b => b.AddConsole());
+            ILogger<CommandLineParser.CommandLineParser> logger = factory.CreateLogger<CommandLineParser.CommandLineParser>();
+            var parser = new CommandLineParser.CommandLineParser(logger);
             var options = new DeclarativeValueTestOptionsFalse();
             parser.ExtractArgumentAttributes(options);
 

--- a/src/Tests/Tests.EqualSignSyntax.cs
+++ b/src/Tests/Tests.EqualSignSyntax.cs
@@ -1,5 +1,6 @@
 using CommandLineParser.Arguments;
 using CommandLineParser.Exceptions;
+using Microsoft.Extensions.Logging;
 using ParserTest;
 using System.Collections.Generic;
 using Xunit;
@@ -10,7 +11,9 @@ namespace Tests
     {
         private CommandLineParser.CommandLineParser InitEqualSignSyntax()
         {
-            var commandLineParser = new CommandLineParser.CommandLineParser();
+            var factory = LoggerFactory.Create(b => b.AddConsole());
+            ILogger<CommandLineParser.CommandLineParser> logger = factory.CreateLogger<CommandLineParser.CommandLineParser>();
+            var commandLineParser = new CommandLineParser.CommandLineParser(logger);
             commandLineParser.AcceptEqualSignSyntaxForValueArguments = true;
             commandLineParser.ShowUsageOnEmptyCommandline = true;
 
@@ -154,7 +157,9 @@ namespace Tests
         {
             string[] args = new[] { "-n=\"1,2,3\"", "x" };
 
-            var commandLineParser = new CommandLineParser.CommandLineParser();
+            var factory = LoggerFactory.Create(b => b.AddConsole());
+            ILogger<CommandLineParser.CommandLineParser> logger = factory.CreateLogger<CommandLineParser.CommandLineParser>();
+            var commandLineParser = new CommandLineParser.CommandLineParser(logger);
             commandLineParser.AcceptEqualSignSyntaxForValueArguments = true;
             ValueArgument<int> lines = new ValueArgument<int>('n', "lines", "Specific lines") { AllowMultiple = true };
             commandLineParser.Arguments.Add(lines);
@@ -164,7 +169,7 @@ namespace Tests
 
             // ASSERT
             Assert.Equal(new List<int> { 1, 2, 3 }, lines.Values);
-            Assert.Equal(1, commandLineParser.AdditionalArgumentsSettings.AdditionalArguments.Length);
+            Assert.Single(commandLineParser.AdditionalArgumentsSettings.AdditionalArguments);
             Assert.Equal("x", commandLineParser.AdditionalArgumentsSettings.AdditionalArguments[0]);
         }
 
@@ -173,7 +178,9 @@ namespace Tests
         {
             string[] args = new[] { "-n=1,2,3", "-n=4" };
 
-            var commandLineParser = new CommandLineParser.CommandLineParser();
+            var factory = LoggerFactory.Create(b => b.AddConsole());
+            ILogger<CommandLineParser.CommandLineParser> logger = factory.CreateLogger<CommandLineParser.CommandLineParser>();
+            var commandLineParser = new CommandLineParser.CommandLineParser(logger);
             commandLineParser.AcceptEqualSignSyntaxForValueArguments = true;
             ValueArgument<int> lines = new ValueArgument<int>('n', "lines", "Specific lines") { AllowMultiple = true };
             commandLineParser.Arguments.Add(lines);
@@ -190,7 +197,9 @@ namespace Tests
         {
             string[] args = new[] { "-n=", "-n=" };
 
-            var commandLineParser = new CommandLineParser.CommandLineParser();
+            var factory = LoggerFactory.Create(b => b.AddConsole());
+            ILogger<CommandLineParser.CommandLineParser> logger = factory.CreateLogger<CommandLineParser.CommandLineParser>();
+            var commandLineParser = new CommandLineParser.CommandLineParser(logger);
             commandLineParser.AcceptEqualSignSyntaxForValueArguments = true;
             ValueArgument<int> lines = new ValueArgument<int>('n', "lines", "Specific lines") { AllowMultiple = true, ValueOptional=true };
             commandLineParser.Arguments.Add(lines);

--- a/src/Tests/Tests.GroupCertifications.cs
+++ b/src/Tests/Tests.GroupCertifications.cs
@@ -2,6 +2,7 @@ using CommandLineParser.Arguments;
 using CommandLineParser.Validation;
 using CommandLineParser.Exceptions;
 using Xunit;
+using Microsoft.Extensions.Logging;
 
 namespace Tests
 {
@@ -39,7 +40,9 @@ namespace Tests
 
         private CommandLineParser.CommandLineParser InitGroupCertifications()
         {
-            var commandLineParser = new CommandLineParser.CommandLineParser();
+            var factory = LoggerFactory.Create(b => b.AddConsole());
+            ILogger<CommandLineParser.CommandLineParser> logger = factory.CreateLogger<CommandLineParser.CommandLineParser>();
+            var commandLineParser = new CommandLineParser.CommandLineParser(logger);
 
             Archiver a = new Archiver();
 
@@ -439,7 +442,9 @@ namespace Tests
         [Fact]
         public void ArgumentRequiresOtherArgumentsCertification_shouldPass_whenDefaultValuesAreThere()
         {
-            var commandLineParser = new CommandLineParser.CommandLineParser();
+            var factory = LoggerFactory.Create(b => b.AddConsole());
+            ILogger<CommandLineParser.CommandLineParser> logger = factory.CreateLogger<CommandLineParser.CommandLineParser>();
+            var commandLineParser = new CommandLineParser.CommandLineParser(logger);
             var parsingTarget = new TestDefaultValues();
             commandLineParser.ExtractArgumentAttributes(parsingTarget);
 

--- a/src/Tests/Tests.IgnoreCase.cs
+++ b/src/Tests/Tests.IgnoreCase.cs
@@ -1,5 +1,6 @@
 using CommandLineParser.Arguments;
 using CommandLineParser.Exceptions;
+using Microsoft.Extensions.Logging;
 using ParserTest;
 using Xunit;
 
@@ -9,7 +10,9 @@ namespace Tests
     {
         private CommandLineParser.CommandLineParser InitIgnoreCase()
         {
-            var commandLineParser = new CommandLineParser.CommandLineParser();
+            var factory = LoggerFactory.Create(b => b.AddConsole());
+            ILogger<CommandLineParser.CommandLineParser> logger = factory.CreateLogger<CommandLineParser.CommandLineParser>();
+            var commandLineParser = new CommandLineParser.CommandLineParser(logger); 
             commandLineParser.IgnoreCase = true;
             commandLineParser.ShowUsageOnEmptyCommandline = true;
 

--- a/src/Tests/Tests.ImperativeArguments.cs
+++ b/src/Tests/Tests.ImperativeArguments.cs
@@ -1,5 +1,6 @@
 using CommandLineParser.Arguments;
 using CommandLineParser.Exceptions;
+using Microsoft.Extensions.Logging;
 using ParserTest;
 using Xunit;
 
@@ -9,7 +10,9 @@ namespace Tests
     {
         private CommandLineParser.CommandLineParser InitImperativeArguments()
         {
-            var commandLineParser = new CommandLineParser.CommandLineParser();
+            var factory = LoggerFactory.Create(b => b.AddConsole());
+            ILogger<CommandLineParser.CommandLineParser> logger = factory.CreateLogger<CommandLineParser.CommandLineParser>();
+            var commandLineParser = new CommandLineParser.CommandLineParser(logger);
             commandLineParser.ShowUsageOnEmptyCommandline = true;
 
             SwitchArgument showArgument = new SwitchArgument('s', "show", "Set whether show or not", true);

--- a/src/Tests/Tests.Parser.cs
+++ b/src/Tests/Tests.Parser.cs
@@ -1,5 +1,6 @@
 using System;
 using CommandLineParser.Arguments;
+using Microsoft.Extensions.Logging;
 using Xunit;
 
 namespace Tests;
@@ -34,7 +35,9 @@ public partial class Tests
     public void Parser_shouldAllowArgsWithTheSameToUpperConversion_whenIgnoreCaseIsNotUsed()
     {
         // ARRANGE 
-        var parser = new CommandLineParser.CommandLineParser();
+        var factory = LoggerFactory.Create(b => b.AddConsole());
+        ILogger<CommandLineParser.CommandLineParser> logger = factory.CreateLogger<CommandLineParser.CommandLineParser>();
+        var parser = new CommandLineParser.CommandLineParser(logger);
         parser.Arguments.Add(new SwitchArgument('a', "switch", false));
         parser.Arguments.Add(new SwitchArgument('b', "SWiTCH", false));
         parser.IgnoreCase = false;
@@ -47,7 +50,9 @@ public partial class Tests
     public void Parser_shouldFailWithArgsWithTheSameToUpperConversion_whenIgnoreCaseIsUsed()
     {
         // ARRANGE 
-        var parser = new CommandLineParser.CommandLineParser();
+        var factory = LoggerFactory.Create(b => b.AddConsole());
+        ILogger<CommandLineParser.CommandLineParser> logger = factory.CreateLogger<CommandLineParser.CommandLineParser>();
+        var parser = new CommandLineParser.CommandLineParser(logger);
         parser.Arguments.Add(new SwitchArgument('a', "switch", false));
         parser.Arguments.Add(new SwitchArgument('b', "SWiTCH", false));
         parser.IgnoreCase = true;
@@ -60,7 +65,9 @@ public partial class Tests
     public void Parser_shouldAcceptSwitch_WithoutShortName()
     {
         // ARRANGE 
-        var parser = new CommandLineParser.CommandLineParser();
+        var factory = LoggerFactory.Create(b => b.AddConsole());
+        ILogger<CommandLineParser.CommandLineParser> logger = factory.CreateLogger<CommandLineParser.CommandLineParser>();
+        var parser = new CommandLineParser.CommandLineParser(logger);
         var switchArgument = new SwitchArgument("switch", false);
         parser.Arguments.Add(switchArgument);
 

--- a/src/Tests/Tests.RegexValueArgument.cs
+++ b/src/Tests/Tests.RegexValueArgument.cs
@@ -1,6 +1,7 @@
 using CommandLineParser.Arguments;
 using CommandLineParser.Exceptions;
 using FluentAssertions;
+using Microsoft.Extensions.Logging;
 using Xunit;
 
 namespace Tests;
@@ -28,7 +29,9 @@ public partial class Tests
 
     private (CommandLineParser.CommandLineParser Parser, RegexValueArgumentParsingTarget ParsingTarget) InitForRegexValueArgument()
     {
-        var commandLineParser = new CommandLineParser.CommandLineParser();
+        var factory = LoggerFactory.Create(b => b.AddConsole());
+        ILogger<CommandLineParser.CommandLineParser> logger = factory.CreateLogger<CommandLineParser.CommandLineParser>();
+        var commandLineParser = new CommandLineParser.CommandLineParser(logger);
         var regexValueArgumentParsingTarget = new RegexValueArgumentParsingTarget();
         commandLineParser.ExtractArgumentAttributes(regexValueArgumentParsingTarget);
 

--- a/src/Tests/Tests.ValueArgument.cs
+++ b/src/Tests/Tests.ValueArgument.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using CommandLineParser.Arguments;
 using CommandLineParser.Exceptions;
+using Microsoft.Extensions.Logging;
 using Xunit;
 
 namespace Tests;
@@ -40,7 +41,9 @@ public partial class Tests
 
     private (CommandLineParser.CommandLineParser Parser, ValueArgumentParsingTarget ParsingTarget) InitValueArgument()
     {
-        var commandLineParser = new CommandLineParser.CommandLineParser();
+        var factory = LoggerFactory.Create(b => b.AddConsole());
+        ILogger<CommandLineParser.CommandLineParser> logger = factory.CreateLogger<CommandLineParser.CommandLineParser>();
+        var commandLineParser = new CommandLineParser.CommandLineParser(logger);
         var valueArgumentTarget = new ValueArgumentParsingTarget();
         commandLineParser.ExtractArgumentAttributes(valueArgumentTarget);
         return (commandLineParser, valueArgumentTarget);


### PR DESCRIPTION
Replace console.Write with Microsoft logging extensions. Also retain support only for .Net Standard 2.0 and 2.1